### PR TITLE
Add source path to compositor mounts

### DIFF
--- a/varp-cli/src/main/kotlin/net/voxelpi/varp/cli/VarpCLI.kt
+++ b/varp-cli/src/main/kotlin/net/voxelpi/varp/cli/VarpCLI.kt
@@ -36,7 +36,7 @@ object VarpCLI {
         registerRepositoryType(FileTreeRepositoryType)
         registerRepositoryType(MySQLRepositoryType)
 
-        addDefaultRepository("default", FileTreeRepositoryType, FileTreeRepositoryConfig(Path("./default/"), "json", false), listOf(RootPath))
+        addDefaultRepository("default", FileTreeRepositoryType, FileTreeRepositoryConfig(Path("./default/"), "json", false), listOf(RootPath to RootPath))
     }
 
     var tree: Tree = loader.tree

--- a/varp-core/src/main/kotlin/net/voxelpi/varp/warp/repository/compositor/CompositorMount.kt
+++ b/varp-core/src/main/kotlin/net/voxelpi/varp/warp/repository/compositor/CompositorMount.kt
@@ -5,10 +5,12 @@ import net.voxelpi.varp.warp.repository.Repository
 
 /**
  * Specifies a mount of a tree compositor.
- * @property path the path where the repository should be mounted.
- * @property repository the repository that should be mounted.
+ * @property path The path where the repository should be mounted.
+ * @property repository The repository that should be mounted.
+ * @property sourcePath The path of the container in the repository that is mounted to the tree.
  */
 public data class CompositorMount(
     val path: NodeParentPath,
     val repository: Repository,
+    val sourcePath: NodeParentPath,
 )

--- a/varp-core/src/test/kotlin/net/voxelpi/varp/warp/repository/compositor/CompositorTest.kt
+++ b/varp-core/src/test/kotlin/net/voxelpi/varp/warp/repository/compositor/CompositorTest.kt
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.Component
 import net.voxelpi.varp.MinecraftLocation
 import net.voxelpi.varp.warp.path.FolderPath
 import net.voxelpi.varp.warp.path.NodeParentPath
+import net.voxelpi.varp.warp.path.RootPath
 import net.voxelpi.varp.warp.path.WarpPath
 import net.voxelpi.varp.warp.repository.ephemeral.EphemeralRepository
 import net.voxelpi.varp.warp.state.FolderState
@@ -27,10 +28,10 @@ class CompositorTest {
             "main",
             CompositorConfig(
                 listOf(
-                    CompositorMount(NodeParentPath.parse("/").getOrThrow(), repo0),
-                    CompositorMount(NodeParentPath.parse("/data1/").getOrThrow(), repo1),
-                    CompositorMount(NodeParentPath.parse("/data2/").getOrThrow(), repo2),
-                    CompositorMount(NodeParentPath.parse("/data2/data3/").getOrThrow(), repo3),
+                    CompositorMount(NodeParentPath.parse("/").getOrThrow(), repo0, RootPath),
+                    CompositorMount(NodeParentPath.parse("/data1/").getOrThrow(), repo1, RootPath),
+                    CompositorMount(NodeParentPath.parse("/data2/").getOrThrow(), repo2, RootPath),
+                    CompositorMount(NodeParentPath.parse("/data2/data3/").getOrThrow(), repo3, RootPath),
                 ),
             ),
         )
@@ -92,7 +93,7 @@ class CompositorTest {
             "main",
             CompositorConfig(
                 listOf(
-                    CompositorMount(NodeParentPath.parse("/test/repo/").getOrThrow(), repo),
+                    CompositorMount(NodeParentPath.parse("/test/repo/").getOrThrow(), repo, RootPath),
                 ),
             ),
         )

--- a/varp-loader/src/main/kotlin/net/voxelpi/varp/loader/VarpLoader.kt
+++ b/varp-loader/src/main/kotlin/net/voxelpi/varp/loader/VarpLoader.kt
@@ -242,7 +242,7 @@ public class VarpLoader internal constructor(
                     continue
                 }
 
-                val mount = CompositorMount(mountDefinition.path, repository)
+                val mount = CompositorMount(mountDefinition.path, repository, mountDefinition.sourcePath)
                 mounts.add(mount)
             }
 
@@ -253,7 +253,7 @@ public class VarpLoader internal constructor(
 
     private fun saveTree(): Result<Unit> {
         return runCatching {
-            val mountDefinitions = compositor.mounts().map { mount -> MountDefinition(mount.path, mount.repository.id) }
+            val mountDefinitions = compositor.mounts().map { mount -> MountDefinition(mount.path, mount.repository.id, mount.sourcePath) }
             val treeConfiguration = TreeConfiguration(mountDefinitions)
 
             // Save the tree file.
@@ -293,10 +293,10 @@ public class VarpLoader internal constructor(
         /**
          * Adds a new default repository with default mounts.
          */
-        public fun <C : RepositoryConfig> addDefaultRepository(id: String, type: RepositoryType<*, C>, config: C, mounts: Collection<NodeParentPath>): Builder {
+        public fun <C : RepositoryConfig> addDefaultRepository(id: String, type: RepositoryType<*, C>, config: C, mounts: Collection<Pair<NodeParentPath, NodeParentPath>>): Builder {
             defaultRepositories[id] = RepositoryDefinition(id, type, config)
-            for (mount in mounts) {
-                defaultMounts[mount] = MountDefinition(mount, id)
+            for ((path, repositoryPath) in mounts) {
+                defaultMounts[path] = MountDefinition(path, id, repositoryPath)
             }
             return this
         }

--- a/varp-loader/src/main/kotlin/net/voxelpi/varp/loader/VarpLoader.kt
+++ b/varp-loader/src/main/kotlin/net/voxelpi/varp/loader/VarpLoader.kt
@@ -132,7 +132,6 @@ public class VarpLoader internal constructor(
         }
 
         loadTree().onFailure { return Result.failure(it) }
-        compositor.load().getOrElse { return Result.failure(it) }
         return Result.success(Unit)
     }
 
@@ -220,7 +219,7 @@ public class VarpLoader internal constructor(
         }
     }
 
-    private fun loadTree(): Result<Unit> {
+    private suspend fun loadTree(): Result<Unit> {
         return runCatching {
             val treeFile = path.resolve(TREE_FILE)
 

--- a/varp-loader/src/main/kotlin/net/voxelpi/varp/loader/model/MountDefinition.kt
+++ b/varp-loader/src/main/kotlin/net/voxelpi/varp/loader/model/MountDefinition.kt
@@ -6,4 +6,5 @@ import net.voxelpi.varp.warp.path.NodeParentPath
 internal data class MountDefinition(
     val path: NodeParentPath,
     val repository: String,
+    val sourcePath: NodeParentPath,
 )

--- a/varp-mod/varp-platform-fabric/src/main/kotlin/net/voxelpi/varp/mod/fabric/server/FabricVarpServer.kt
+++ b/varp-mod/varp-platform-fabric/src/main/kotlin/net/voxelpi/varp/mod/fabric/server/FabricVarpServer.kt
@@ -59,7 +59,7 @@ class FabricVarpServer(
     override val loader: VarpLoader = VarpLoader.loader(server.getSavePath(WorldSavePath.ROOT).resolve("data").resolve("varp")) {
         registerRepositoryType(FileTreeRepositoryType)
 
-        addDefaultRepository("default", FileTreeRepositoryType, FileTreeRepositoryConfig(Path("./default/"), "json", false), listOf(RootPath))
+        addDefaultRepository("default", FileTreeRepositoryType, FileTreeRepositoryConfig(Path("./default/"), "json", false), listOf(RootPath to RootPath))
     }
 
     override val serverNetworkHandler: FabricVarpServerNetworkHandler = FabricVarpServerNetworkHandler(this)

--- a/varp-mod/varp-platform-paper/src/main/kotlin/net/voxelpi/varp/mod/paper/PaperVarpServer.kt
+++ b/varp-mod/varp-platform-paper/src/main/kotlin/net/voxelpi/varp/mod/paper/PaperVarpServer.kt
@@ -55,7 +55,7 @@ class PaperVarpServer(
     override val loader: VarpLoader = VarpLoader.loader(plugin.dataPath.resolve("data")) {
         registerRepositoryType(FileTreeRepositoryType)
 
-        addDefaultRepository("default", FileTreeRepositoryType, FileTreeRepositoryConfig(Path("./default/"), "json", false), listOf(RootPath))
+        addDefaultRepository("default", FileTreeRepositoryType, FileTreeRepositoryConfig(Path("./default/"), "json", false), listOf(RootPath to RootPath))
     }
 
     override val serverNetworkHandler: PaperVarpServerNetworkHandler = PaperVarpServerNetworkHandler(this)


### PR DESCRIPTION
Add config option "source_path" to compositor mounts, that allows mounting only a subfolder of a repository.